### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 FIND_PACKAGE(PythonInterp "3")
-FIND_PACKAGE(PythonLibs"3")
+FIND_PACKAGE(PythonLibs "3")
 FIND_PACKAGE(Boost COMPONENTS python)
 
 ENABLE_TESTING()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
-FIND_PACKAGE(PythonInterp)
-FIND_PACKAGE(PythonLibs)
+FIND_PACKAGE(PythonInterp "3")
+FIND_PACKAGE(PythonLibs"3")
 FIND_PACKAGE(Boost COMPONENTS python)
 
 ENABLE_TESTING()


### PR DESCRIPTION
without this modification, cmake prompt:
-- Found PythonInterp: /usr/bin/python (found version "2.7.10") 
-- Found PythonLibs: /Library/Frameworks/Python.framework/Versions/3.5/lib/libpython3.5.dylib (found version "2.7.10") 

Update CMakeLists.txt followed:
https://cmake.org/Bug/print_bug_page.php?bug_id=13794

to found python3

OS: MAC10.11.1, XCode: 7.1.1, cmake:3.4.0, Python:3.5, Boost version: 1.59.0

Kevins-Mac:pythonc++ kevin$ cmake .
-- The C compiler identification is AppleClang 7.0.0.7000176
-- The CXX compiler identification is AppleClang 7.0.0.7000176
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PythonInterp: /Library/Frameworks/Python.framework/Versions/3.5/bin/python3 (found suitable version "3.5", minimum required is "3") 
-- Found PythonLibs: /Library/Frameworks/Python.framework/Versions/3.5/lib/libpython3.5m.dylib (found suitable version "3.5.0", minimum required is "3") 
-- Boost version: 1.59.0
-- Found the following Boost libraries:
--   python
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/kevin/Desktop/pythonc++