### PR TITLE
CTest to run detected interpreter

### DIFF
--- a/01-HelloWorld/CMakeLists.txt
+++ b/01-HelloWorld/CMakeLists.txt
@@ -1,4 +1,4 @@
 
 PYTHON_ADD_MODULE(hello hello.cpp)
 FILE(COPY hello.py DESTINATION .)
-ADD_TEST(01-HelloWorld hello.py)
+ADD_TEST(NAME 01-HelloWorld COMMAND ${PYTHON_EXECUTABLE} hello.py)

--- a/02-ExposingClasses/CMakeLists.txt
+++ b/02-ExposingClasses/CMakeLists.txt
@@ -1,4 +1,4 @@
 
 PYTHON_ADD_MODULE(classes classes.cpp)
 FILE(COPY classes.py DESTINATION .)
-ADD_TEST(02-ExposingClasses classes.py)
+ADD_TEST(NAME 02-ExposingClasses COMMAND ${PYTHON_EXECUTABLE} classes.py)

--- a/03-Constructors/CMakeLists.txt
+++ b/03-Constructors/CMakeLists.txt
@@ -1,4 +1,4 @@
 
 PYTHON_ADD_MODULE(ctor ctor.cpp)
 FILE(COPY ctor.py DESTINATION .)
-ADD_TEST(03-Constructors ctor.py)
+ADD_TEST(NAME 03-Constructors COMMAND ${PYTHON_EXECUTABLE} ctor.py)

--- a/04-ClassMembers/CMakeLists.txt
+++ b/04-ClassMembers/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 PYTHON_ADD_MODULE(member member.cpp)
 FILE(COPY member.py DESTINATION .)
-ADD_TEST(04-ClassMembers member.py)
+ADD_TEST(NAME 04-ClassMembers COMMAND ${PYTHON_EXECUTABLE} member.py)
 

--- a/05-Inheritance/CMakeLists.txt
+++ b/05-Inheritance/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 PYTHON_ADD_MODULE(inheritance inheritance.cpp)
 FILE(COPY inheritance.py DESTINATION .)
-ADD_TEST(05-Inheritance inheritance.py)
+ADD_TEST(NAME 05-Inheritance COMMAND ${PYTHON_EXECUTABLE} inheritance.py)
 

--- a/06-VirtualFunctionsInPython/CMakeLists.txt
+++ b/06-VirtualFunctionsInPython/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 PYTHON_ADD_MODULE(virtual virtual.cpp)
 FILE(COPY virtual.py DESTINATION .)
-ADD_TEST(06-VirtualFunctionsInPython virtual.py)
+ADD_TEST(NAME 06-VirtualFunctionsInPython COMMAND ${PYTHON_EXECUTABLE} virtual.py)
 

--- a/07-Operators/CMakeLists.txt
+++ b/07-Operators/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 PYTHON_ADD_MODULE(operators operators.cpp)
 FILE(COPY operators.py DESTINATION .)
-ADD_TEST(07-Operators operators.py)
+ADD_TEST(NAME 07-Operators COMMAND ${PYTHON_EXECUTABLE} operators.py)
 

--- a/08-CallPolicies/CMakeLists.txt
+++ b/08-CallPolicies/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 PYTHON_ADD_MODULE(policies policies.cpp)
 FILE(COPY policies.py DESTINATION .)
-ADD_TEST(08-CallPolicies policies.py)
+ADD_TEST(NAME 08-CallPolicies COMMAND ${PYTHON_EXECUTABLE} policies.py)
 

--- a/09-Overloading/CMakeLists.txt
+++ b/09-Overloading/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 PYTHON_ADD_MODULE(overload overload.cpp)
 FILE(COPY overload.py DESTINATION .)
-ADD_TEST(09-Overloading overload.py)
+ADD_TEST(NAME 09-Overloading COMMAND ${PYTHON_EXECUTABLE} overload.py)
 

--- a/10-Embedding/CMakeLists.txt
+++ b/10-Embedding/CMakeLists.txt
@@ -3,5 +3,5 @@ PYTHON_ADD_MODULE(mymodule mymodule.cpp)
 ADD_EXECUTABLE(embedding mymodule.cpp embedding.cpp)
 TARGET_LINK_LIBRARIES(embedding ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
 FILE(COPY embedding.py DESTINATION .)
-ADD_TEST(10-Embedding embedding)
+ADD_TEST(NAME 10-Embedding COMMAND embedding)
 

--- a/11-Iterators/CMakeLists.txt
+++ b/11-Iterators/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 PYTHON_ADD_MODULE(iterators iterators.cpp)
 FILE(COPY iterators.py DESTINATION .)
-ADD_TEST(11-Iterators iterators.py)
+ADD_TEST(NAME 11-Iterators COMMAND ${PYTHON_EXECUTABLE} iterators.py)
 

--- a/12-Exceptions/CMakeLists.txt
+++ b/12-Exceptions/CMakeLists.txt
@@ -1,5 +1,5 @@
 
 PYTHON_ADD_MODULE(myexceptions myexceptions.cpp)
 FILE(COPY myexceptions.py DESTINATION .)
-ADD_TEST(12-Exceptions myexceptions.py)
+ADD_TEST(NAME 12-Exceptions COMMAND ${PYTHON_EXECUTABLE} myexceptions.py)
 

--- a/13-AutoInstantiation/CMakeLists.txt
+++ b/13-AutoInstantiation/CMakeLists.txt
@@ -3,5 +3,5 @@ ADD_EXECUTABLE(auto_instance myextension.cpp auto_instance.cpp)
 TARGET_LINK_LIBRARIES(auto_instance ${Boost_LIBRARIES} ${PYTHON_LIBRARIES})
 FILE(COPY auto_instance.py DESTINATION .)
 SET( ENV{PYTHONPATH} . )
-ADD_TEST(13-AutoInstantiation auto_instance)
+ADD_TEST(NAME 13-AutoInstantiation COMMAND auto_instance)
 


### PR DESCRIPTION
This allows to test with another interpreter (eg python3) than the default one used in the shebangs.